### PR TITLE
feat: async task polling and message delay tweak

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,60 @@
+import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+from app.controller import processar_csv
+
+# Executor global por processo
+_executor = ThreadPoolExecutor(max_workers=4)
+_tasks = {}
+
+
+def enqueue_csv_processing(filepath: str, ignorar_sabados: bool, tipo_relatorio: str,
+                           equipes_selecionadas: Optional[set] = None,
+                           debug_mode: bool = False) -> str:
+    """Agenda o processamento do CSV em background."""
+    task_id = uuid.uuid4().hex
+    _tasks[task_id] = {"status": "queued", "result": None, "error": None}
+
+    def _run():
+        _tasks[task_id]["status"] = "running"
+        try:
+            logs, stats, nome_arquivo_log = processar_csv(
+                filepath, ignorar_sabados, tipo_relatorio, equipes_selecionadas
+            )
+
+            debug_data = None
+            if debug_mode:
+                if tipo_relatorio == "Ocorrências":
+                    from app.processamento.csv_reader_ocorrencias import carregar_dados_ocorrencias
+                    debug_data = carregar_dados_ocorrencias(filepath).to_json(
+                        orient="records", force_ascii=False
+                    )
+                else:
+                    from app.processamento.csv_reader import carregar_dados
+                    debug_data = carregar_dados(
+                        filepath, ignorar_sabados, tipo_relatorio
+                    ).to_json(orient="records", force_ascii=False)
+
+            _tasks[task_id]["result"] = {
+                "logs": logs,
+                "stats": stats,
+                "nome_arquivo_log": nome_arquivo_log,
+                "debug": debug_data,
+            }
+            _tasks[task_id]["status"] = "done"
+        except Exception as e:  # noqa: BLE001 - registrar erro genericamente
+            _tasks[task_id]["error"] = str(e)
+            _tasks[task_id]["status"] = "error"
+        finally:
+            if os.path.exists(filepath):
+                os.remove(filepath)
+
+    _executor.submit(_run)
+    return task_id
+
+
+def get_task_status(task_id: str):
+    """Obtém o dicionário de status/resultado da tarefa."""
+    return _tasks.get(task_id)

--- a/app/whatsapp/enviar_mensagem.py
+++ b/app/whatsapp/enviar_mensagem.py
@@ -1,10 +1,12 @@
-import requests
 import json
 import logging
-import time
-import random
 import os
+import random
+import signal
+import sys
+import time
 
+import requests
 config_path = os.path.join(os.path.dirname(__file__), "..", "..", "static", "config.json")
 with open(config_path, "r", encoding="utf-8") as f:
     config = json.load(f)
@@ -20,36 +22,60 @@ def _get_headers():
         "apikey": EVOLUTION_TOKEN
     }
 
+def signal_handler(signum, frame):
+    """Loga sinais recebidos do sistema e finaliza o processo."""
+    logging.error(f"🚨 SINAL RECEBIDO: {signum} - Worker sendo morto pelo Gunicorn")
+    sys.exit(1)
+
+
+signal.signal(signal.SIGTERM, signal_handler)
+signal.signal(signal.SIGABRT, signal_handler)
+
+
 def enviar_whatsapp(numero, mensagem, equipe=None):
     numero_formatado = numero.replace("+", "").replace("-", "").replace(" ", "")
     url = f"{EVOLUTION_URL}/message/sendText/{EVOLUTION_INSTANCE}"
-    
+
     payload = {
         "number": numero_formatado,
         "text": mensagem,
-        "delay": 50                # Delay antes do envio (ms)
+        "delay": 250,  # Delay antes do envio (ms)
     }
 
     try:
         logging.info(f"⏳ Enviando para {numero_formatado} (Equipe: {equipe})")
         logging.info(f"Payload: {payload}")
 
-        # Envia diretamente com delay e presence no payload
-        response = requests.post(url, json=payload, headers=_get_headers())
+        response = requests.post(
+            url, json=payload, headers=_get_headers(), timeout=30
+        )
 
         logging.info(f"Evolution API status: {response.status_code}")
         logging.info(f"Evolution API response: {response.text}")
 
         if response.status_code not in [200, 201]:
-            raise Exception(f"Erro Evolution API: {response.status_code} - {response.text}")
+            raise Exception(
+                f"Erro Evolution API: {response.status_code} - {response.text}"
+            )
 
         response_data = response.json()
         if not response_data.get("success", True):
-            raise Exception(f"Erro na resposta: {response_data.get('message', 'Erro desconhecido')}")
+            raise Exception(
+                f"Erro na resposta: {response_data.get('message', 'Erro desconhecido')}"
+            )
 
         logging.info(f"✅ Mensagem enviada para {numero_formatado} (Equipe: {equipe})")
-        time.sleep(random.uniform(4, 8))
+        time.sleep(random.uniform(0.25, 0.5))
 
+    except SystemExit as se:
+        logging.error(
+            "🚨 SYSTEMEXIT CAPTURADO - Worker sendo morto pelo Gunicorn!"
+        )
+        logging.error(f"🚨 Exit code: {se.code}")
+        raise
+    except BaseException as be:
+        logging.error(f"🚨 BASEEXCEPTION CAPTURADA: {type(be).__name__}")
+        raise
     except Exception as e:
         logging.error(f"❌ Falha ao enviar para {numero_formatado} - {e}")
         raise

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,6 @@
+import multiprocessing
+
+bind = "0.0.0.0:8000"
+workers = multiprocessing.cpu_count() * 2 + 1
+timeout = 120
+


### PR DESCRIPTION
## Summary
- add 250ms delay to WhatsApp payload and lower post-send pause
- return task id from `/enviar` helper and poll `/status/<id>` on the frontend
- disable send button while polling and surface final logs & stats

## Testing
- `python -m py_compile app/whatsapp/enviar_mensagem.py`
- `node --check static/js/api.js`
- `node --check static/js/eventos.js`


------
https://chatgpt.com/codex/tasks/task_b_68a86cb226a483338e65b92b38d06d1f