### PR TITLE
feat: adicionar relatorio de assinaturas

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -1,5 +1,6 @@
 from app.processamento.csv_reader import carregar_dados
 from app.whatsapp.mensagem import gerar_mensagens
+from app.whatsapp.mensagem_assinaturas import gerar_mensagens_assinaturas
 from app.whatsapp.enviar_mensagem import enviar_whatsapp
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from app.whatsapp.numeros_equipes import carregar_numeros_equipes
@@ -30,76 +31,115 @@ def processar_csv(caminho_csv, ignorar_sabados, tipo_relatorio, equipes_selecion
 
     df["EquipeTratada"] = df["EquipeTratada"].astype(str).str.strip().str.upper()
 
-    mensagens_por_grupo = gerar_mensagens(df, tipo_relatorio)
     numero_equipe = carregar_numeros_equipes()
-    
-    mensagens_por_equipe_data = defaultdict(lambda: defaultdict(list))
+
     logs = []
     equipes_sem_numero = []
     stats = {"total": 0, "equipes": set(), "sucesso": 0, "erro": 0}
 
-    for (nome, data), mensagem in mensagens_por_grupo.items():
-        equipe_match = df.loc[(df["Nome"] == nome) & (df["Data"] == data), "EquipeTratada"]
-        if equipe_match.empty:
-            continue
-        equipe = equipe_match.iloc[0]
-        mensagens_por_equipe_data[equipe][data].append(mensagem)
+    if tipo_relatorio == "Assinaturas":
+        mensagens_por_equipe = gerar_mensagens_assinaturas(df)
+        futures = {}
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            for equipe, mensagem_final in sorted(mensagens_por_equipe.items()):
+                equipe_normalizada = str(equipe).strip().upper()
+                if equipes_selecionadas:
+                    equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
+                    if equipe_normalizada not in equipes_normalizadas:
+                        continue
 
-    futures = {}
-    with ThreadPoolExecutor(max_workers=5) as executor:
-        for equipe, datas in sorted(mensagens_por_equipe_data.items()):
-            equipe_normalizada = str(equipe).strip().upper()
-            if equipes_selecionadas:
-                equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
-                if equipe_normalizada not in equipes_normalizadas:
+                numero = numero_equipe.get(equipe_normalizada)
+                if not numero or numero.strip().lower() in ["nan", "none", ""]:
+                    equipes_sem_numero.append(equipe)
+                    stats["erro"] += 1
                     continue
 
-            numero = numero_equipe.get(equipe_normalizada)
-            if not numero or numero.strip().lower() in ["nan", "none", ""]:
-                equipes_sem_numero.append(equipe)
+                equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
+                titulo = f"LOJA {equipe_normalizada}" if eh_loja(equipe_original) else f"{equipe_normalizada}"
+
+                future = executor.submit(
+                    enviar_whatsapp, numero, mensagem_final.strip(), equipe_normalizada
+                )
+                futures[future] = titulo
+                stats["total"] += 1
+                stats["equipes"].add(equipe_normalizada)
+
+        for future in as_completed(futures):
+            titulo = futures[future]
+            try:
+                future.result()
+                logs.append({"type": "success", "message": f" Mensagem enviada para {titulo}"})
+                stats["sucesso"] += 1
+            except Exception as e:
+                logs.append({"type": "error", "message": f" Erro ao enviar para {titulo}: {str(e)}"})
                 stats["erro"] += 1
+
+    else:
+        mensagens_por_grupo = gerar_mensagens(df, tipo_relatorio)
+        mensagens_por_equipe_data = defaultdict(lambda: defaultdict(list))
+
+        for (nome, data), mensagem in mensagens_por_grupo.items():
+            equipe_match = df.loc[(df["Nome"] == nome) & (df["Data"] == data), "EquipeTratada"]
+            if equipe_match.empty:
                 continue
+            equipe = equipe_match.iloc[0]
+            mensagens_por_equipe_data[equipe][data].append(mensagem)
 
-            mensagens_sub = datas
-            datas_sub = defaultdict(list)
+        futures = {}
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            for equipe, datas in sorted(mensagens_por_equipe_data.items()):
+                equipe_normalizada = str(equipe).strip().upper()
+                if equipes_selecionadas:
+                    equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
+                    if equipe_normalizada not in equipes_normalizadas:
+                        continue
 
-            for data, mensagens in mensagens_sub.items():
-                mensagens_validas = [m for m in mensagens if m and isinstance(m, str)]
-                if mensagens_validas:
-                    datas_sub[data].extend(mensagens_validas)
-
-            if not datas_sub:
-                continue
-
-            equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
-            titulo = f"LOJA {equipe}" if eh_loja(equipe_original) else f"{equipe}"
-            mensagem_final = f"*{titulo}*\n\n"
-
-            for data in sorted(datas_sub.keys(), key=lambda d: datetime.strptime(d, "%d/%m/%Y")):
-                mensagens_validas = [m.strip() for m in datas_sub[data] if m and m.strip()]
-                if not mensagens_validas:
+                numero = numero_equipe.get(equipe_normalizada)
+                if not numero or numero.strip().lower() in ["nan", "none", ""]:
+                    equipes_sem_numero.append(equipe)
+                    stats["erro"] += 1
                     continue
-                mensagem_final += f"*NO DIA {data}:*\n"
-                for m in mensagens_validas:
-                    mensagem_final += f"• {m}\n"
-                mensagem_final += "\n"
 
-            future = executor.submit(
-                enviar_whatsapp, numero, mensagem_final.strip(), equipe
-            )
-            futures[future] = titulo
-            stats["total"] += 1
-            stats["equipes"].add(equipe)
+                mensagens_sub = datas
+                datas_sub = defaultdict(list)
 
-    for future in as_completed(futures):
-        titulo = futures[future]
-        try:
-            future.result()
-            logs.append({"type": "success", "message": f" Mensagem enviada para {titulo}"})
-            stats["sucesso"] += 1
-        except Exception as e:
-            logs.append({"type": "error", "message": f" Erro ao enviar para {titulo}: {str(e)}"})
-            stats["erro"] += 1
+                for data, mensagens in mensagens_sub.items():
+                    mensagens_validas = [m for m in mensagens if m and isinstance(m, str)]
+                    if mensagens_validas:
+                        datas_sub[data].extend(mensagens_validas)
+
+                if not datas_sub:
+                    continue
+
+                equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
+                titulo = f"LOJA {equipe}" if eh_loja(equipe_original) else f"{equipe}"
+                mensagem_final = f"*{titulo}*\n\n"
+
+                for data in sorted(datas_sub.keys(), key=lambda d: datetime.strptime(d, "%d/%m/%Y")):
+                    mensagens_validas = [m.strip() for m in datas_sub[data] if m and m.strip()]
+                    if not mensagens_validas:
+                        continue
+                    mensagem_final += f"*NO DIA {data}:*\n"
+                    for m in mensagens_validas:
+                        mensagem_final += f"• {m}\n"
+                    mensagem_final += "\n"
+
+                future = executor.submit(
+                    enviar_whatsapp, numero, mensagem_final.strip(), equipe
+                )
+                futures[future] = titulo
+                stats["total"] += 1
+                stats["equipes"].add(equipe)
+
+        for future in as_completed(futures):
+            titulo = futures[future]
+            try:
+                future.result()
+                logs.append({"type": "success", "message": f" Mensagem enviada para {titulo}"})
+                stats["sucesso"] += 1
+            except Exception as e:
+                logs.append({"type": "error", "message": f" Erro ao enviar para {titulo}: {str(e)}"})
+                stats["erro"] += 1
 
     if equipes_sem_numero:
         logs.append({"type": "warning", "message": f" Números não encontrados para: {', '.join(equipes_sem_numero)}"})

--- a/app/processamento/csv_reader.py
+++ b/app/processamento/csv_reader.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from app.processamento.mapear_gerencia import mapear_equipe
 from app.processamento.csv_reader_ocorrencias import carregar_dados_ocorrencias
+from app.processamento.csv_reader_assinaturas import carregar_dados_assinaturas
 from app.whatsapp.mensagem import validar_ocorrencia
 
 def carregar_dados(caminho_csv, ignorar_sabados, tipo_relatorio):
@@ -49,7 +50,9 @@ def carregar_dados(caminho_csv, ignorar_sabados, tipo_relatorio):
         return df
     elif tipo_relatorio == "Ocorrências":
         return carregar_dados_ocorrencias(caminho_csv)
+    elif tipo_relatorio == "Assinaturas":
+        return carregar_dados_assinaturas(caminho_csv)
     else:
-        raise ValueError("Tipo de relatório inválido. Escolha 'Auditoria' ou 'Ocorrências'.")
+        raise ValueError("Tipo de relatório inválido. Escolha 'Auditoria', 'Ocorrências' ou 'Assinaturas'.")
 
 

--- a/app/processamento/csv_reader_assinaturas.py
+++ b/app/processamento/csv_reader_assinaturas.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from app.processamento.mapear_gerencia import mapear_equipe
+
+
+def carregar_dados_assinaturas(caminho_csv):
+    """Carrega dados para o relatório de Assinaturas.
+
+    - Ignora as 4 primeiras linhas e as 3 últimas.
+    - Valida colunas necessárias.
+    - Renomeia 'Colaborador' para 'Nome'.
+    - Cria coluna 'EquipeTratada' usando ``mapear_equipe``.
+    - Filtra apenas colaboradores com 'Assinado?' == 'Não'.
+    - Mantém 'Período (Fechamento)' para composição das mensagens.
+    """
+    # Leitura do CSV considerando linhas a pular
+    df = pd.read_csv(caminho_csv, skiprows=4, skipfooter=3, engine="python")
+
+    # Validação de colunas obrigatórias
+    colunas_necessarias = [
+        "Colaborador",
+        "Equipe",
+        "Período (Fechamento)",
+        "Assinado?",
+    ]
+    colunas_faltantes = [c for c in colunas_necessarias if c not in df.columns]
+    if colunas_faltantes:
+        raise ValueError(f"Colunas faltantes no arquivo CSV: {colunas_faltantes}")
+
+    # Normalização e renomeação de colunas
+    df.rename(columns={"Colaborador": "Nome"}, inplace=True)
+    for coluna in ["Nome", "Equipe", "Período (Fechamento)", "Assinado?"]:
+        df[coluna] = df[coluna].astype(str).str.strip()
+
+    # Mapear equipes
+    df["EquipeTratada"] = df["Equipe"].apply(mapear_equipe)
+
+    # Filtrar apenas colaboradores não assinados
+    df = df[df["Assinado?"].str.lower() == "não"]
+
+    # Manter apenas colunas relevantes
+    return df[["Nome", "Equipe", "EquipeTratada", "Período (Fechamento)"]]

--- a/app/routes.py
+++ b/app/routes.py
@@ -18,10 +18,10 @@ def enviar():
         file = request.files.get('csvFile')
         ignorar_sabados = request.form.get('ignorarSabados', 'true') == 'true'
         tipo_relatorio = request.form.get('tipoRelatorio', 'Auditoria').strip()
-        if tipo_relatorio not in {"Auditoria", "Ocorrências"}:
+        if tipo_relatorio not in {"Auditoria", "Ocorrências", "Assinaturas"}:
             return jsonify({
                 "success": False,
-                "log": [{"type": "error", "message": f"❌ Tipo de relatório inválido: {tipo_relatorio}. Selecione 'Auditoria' ou 'Ocorrências'."}]
+                "log": [{"type": "error", "message": f"❌ Tipo de relatório inválido: {tipo_relatorio}. Selecione 'Auditoria', 'Ocorrências' ou 'Assinaturas'."}]
             }), 400
 
         debug_mode = request.form.get('debugMode', 'false') == 'true'
@@ -91,6 +91,11 @@ def obter_equipes():
     file = request.files.get('csvFile')
     ignorar_sabados = request.form.get('ignorarSabados', 'true') == 'true'
     tipo_relatorio = request.form.get('tipoRelatorio', 'Auditoria')
+    if tipo_relatorio not in {"Auditoria", "Ocorrências", "Assinaturas"}:
+        return jsonify({
+            "success": False,
+            "error": f"Tipo de relatório inválido: {tipo_relatorio}"
+        }), 400
 
     if not file or not file.filename.lower().endswith('csv'):
         return jsonify({"success": False, "error": "Arquivo CSV inválido"}), 400

--- a/app/whatsapp/mensagem_assinaturas.py
+++ b/app/whatsapp/mensagem_assinaturas.py
@@ -1,0 +1,35 @@
+from collections import Counter
+
+
+def gerar_mensagens_assinaturas(df):
+    """Gera um dicionário de mensagens por equipe para o relatório de Assinaturas.
+
+    Retorna um dicionário {equipe_tratada: mensagem_final} para cada equipe que
+    possui pelo menos um colaborador com pendência de assinatura.
+    """
+    mensagens = {}
+    if df.empty:
+        return mensagens
+
+    for equipe, grupo in df.groupby("EquipeTratada"):
+        nomes = grupo["Nome"].dropna().tolist()
+        if not nomes:
+            continue
+
+        periodos = grupo["Período (Fechamento)"].dropna().tolist()
+        if periodos:
+            # Usa o período mais frequente; se empate, pega o primeiro
+            periodo_counter = Counter(periodos)
+            mes = periodo_counter.most_common(1)[0][0]
+        else:
+            mes = ""
+
+        linhas = "\n".join(f"- {n}" for n in nomes)
+        mensagem = (
+            f"ASSINATURA DE ESPELHO PONTO LOJA {equipe}\n"
+            f"Os colaboradores abaixo não assinaram o espelho ponto do mês {mes}\n"
+            f"{linhas}"
+        ).strip()
+        mensagens[equipe] = mensagem
+
+    return mensagens

--- a/static/js/eventos.js
+++ b/static/js/eventos.js
@@ -46,6 +46,8 @@ export function configurarEventos() {
                     msgErro = "❌ O tipo de relatório selecionado foi 'Ocorrências', mas o arquivo não contém as colunas esperadas ('Motivo', 'Ação pendente', etc).";
                 } else if (tipoRelatorioAtual === "Auditoria") {
                     msgErro = "❌ O tipo de relatório selecionado foi 'Auditoria', mas o arquivo está em formato incorreto.";
+                } else if (tipoRelatorioAtual === "Assinaturas") {
+                    msgErro = "❌ O tipo de relatório selecionado foi 'Assinaturas', mas o arquivo está em formato incorreto.";
                 }
 
                 throw new Error(msgErro);

--- a/static/js/tipo-dropdown.js
+++ b/static/js/tipo-dropdown.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const tipoSelectedText = document.getElementById('tipoSelectedText');
     const tipoRelatorioInput = document.getElementById('tipoRelatorio');
     const tipoDropdownItems = document.querySelectorAll('.tipo-dropdown-item');
+    const ignorarSabadosCheckbox = document.getElementById('ignorarSabados');
+    const ignorarSabadosLabel = document.querySelector('label[for="ignorarSabados"]');
 
     // Toggle dropdown
     tipoDropdownHeader.addEventListener('click', function() {
@@ -57,6 +59,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // Habilitar upload
             atualizarStatusUpload();
+
+            // Desabilitar checkbox de sábados para Assinaturas
+            if (value === 'Assinaturas') {
+                ignorarSabadosCheckbox.disabled = true;
+                ignorarSabadosLabel.classList.add('upload-disabled');
+            } else {
+                ignorarSabadosCheckbox.disabled = false;
+                ignorarSabadosLabel.classList.remove('upload-disabled');
+            }
         });
     });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -114,6 +114,10 @@
                                     <span class="tipo-icon">⚠️</span>
                                     <span class="tipo-text">Ocorrências</span>
                                 </div>
+                                <div class="tipo-dropdown-item" data-value="Assinaturas">
+                                    <span class="tipo-icon">📝</span>
+                                    <span class="tipo-text">Assinaturas</span>
+                                </div>
                             </div>
                         </div>
                         <input type="hidden" id="tipoRelatorio" value="">


### PR DESCRIPTION
## Summary
- add signature report support in backend and frontend
- generate whatsapp messages per team for unsigned points
- update dropdown and error handling for new report type

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68adedef17a48333b3e97b66c149dd8b