### PR TITLE
Diferenciar mensagens de assinatura por loja ou setor

### DIFF
--- a/app/whatsapp/mensagem_assinaturas.py
+++ b/app/whatsapp/mensagem_assinaturas.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import re
 
 
 def gerar_mensagens_assinaturas(df):
@@ -25,8 +26,14 @@ def gerar_mensagens_assinaturas(df):
             mes = ""
 
         linhas = "\n".join(f"- {n}" for n in nomes)
+
+        if re.fullmatch(r"[A-Z]?\d{1,3}[A-Z]?", equipe):
+            titulo = f"LOJA {equipe}"
+        else:
+            titulo = f"ASSINATURA DE ESPELHO PONTO | {equipe}"
+
         mensagem = (
-            f"ASSINATURA DE ESPELHO PONTO LOJA {equipe}\n"
+            f"{titulo}\n"
             f"Os colaboradores abaixo não assinaram o espelho ponto do mês {mes}\n"
             f"{linhas}"
         ).strip()


### PR DESCRIPTION
## Summary
- Ajusta geração de mensagens de assinaturas para usar "LOJA" quando equipe for código de loja.
- Para setores, mensagem passa a usar "ASSINATURA DE ESPELHO PONTO | {setor}".

## Testing
- `pytest`
- `python -m py_compile app/whatsapp/mensagem_assinaturas.py`


------
https://chatgpt.com/codex/tasks/task_b_68adf51f50c48333a0fe39a72acc5e06