### PR TITLE
Filtra colaboradores já assinados no relatório de assinaturas

### DIFF
--- a/app/whatsapp/mensagem_assinaturas.py
+++ b/app/whatsapp/mensagem_assinaturas.py
@@ -7,10 +7,18 @@ def gerar_mensagens_assinaturas(df):
 
     Retorna um dicionário {equipe_tratada: mensagem_final} para cada equipe que
     possui pelo menos um colaborador com pendência de assinatura.
+
+    Caso a coluna ``Assinado?`` esteja presente, apenas colaboradores com valor
+    "Não" permanecerão na lista e, consequentemente, na prévia de envio.
     """
     mensagens = {}
     if df.empty:
         return mensagens
+
+    if "Assinado?" in df.columns:
+        df = df[df["Assinado?"].astype(str).str.strip().str.lower() == "não"]
+        if df.empty:
+            return mensagens
 
     for equipe, grupo in df.groupby("EquipeTratada"):
         nomes = grupo["Nome"].dropna().tolist()


### PR DESCRIPTION
## Summary
- Filtra a listagem de mensagens para considerar apenas colaboradores com `Assinado? = Não`
- Atualiza a documentação da função de geração de mensagens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68adfc4113e08333a7eadd14d15a8b41