### PR TITLE
fix: enviar mensagens de forma sequencial com atraso

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -2,13 +2,13 @@ from app.processamento.csv_reader import carregar_dados
 from app.whatsapp.mensagem import gerar_mensagens
 from app.whatsapp.mensagem_assinaturas import gerar_mensagens_assinaturas
 from app.whatsapp.enviar_mensagem import enviar_whatsapp
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from app.whatsapp.numeros_equipes import carregar_numeros_equipes
 from app.processamento.log import configurar_log
 from app.processamento.mapear_gerencia import eh_loja
 from collections import defaultdict
 from datetime import datetime
 import logging
+import time
 import pandas as pd
 
 def processar_csv(caminho_csv, ignorar_sabados, tipo_relatorio, equipes_selecionadas=None):
@@ -39,40 +39,44 @@ def processar_csv(caminho_csv, ignorar_sabados, tipo_relatorio, equipes_selecion
 
     if tipo_relatorio == "Assinaturas":
         mensagens_por_equipe = gerar_mensagens_assinaturas(df)
-        futures = {}
-        with ThreadPoolExecutor(max_workers=5) as executor:
-            for equipe, mensagem_final in sorted(mensagens_por_equipe.items()):
-                equipe_normalizada = str(equipe).strip().upper()
-                if equipes_selecionadas:
-                    equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
-                    if equipe_normalizada not in equipes_normalizadas:
-                        continue
-
-                numero = numero_equipe.get(equipe_normalizada)
-                if not numero or numero.strip().lower() in ["nan", "none", ""]:
-                    equipes_sem_numero.append(equipe)
-                    stats["erro"] += 1
+        for equipe, mensagem_final in sorted(mensagens_por_equipe.items()):
+            equipe_normalizada = str(equipe).strip().upper()
+            if equipes_selecionadas:
+                equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
+                if equipe_normalizada not in equipes_normalizadas:
                     continue
 
-                equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
-                titulo = f"LOJA {equipe_normalizada}" if eh_loja(equipe_original) else f"{equipe_normalizada}"
+            numero = numero_equipe.get(equipe_normalizada)
+            if not numero or numero.strip().lower() in ["nan", "none", ""]:
+                equipes_sem_numero.append(equipe)
+                stats["erro"] += 1
+                continue
 
-                future = executor.submit(
-                    enviar_whatsapp, numero, mensagem_final.strip(), equipe_normalizada
-                )
-                futures[future] = titulo
-                stats["total"] += 1
-                stats["equipes"].add(equipe_normalizada)
+            equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
+            titulo = (
+                f"LOJA {equipe_normalizada}"
+                if eh_loja(equipe_original)
+                else f"{equipe_normalizada}"
+            )
 
-        for future in as_completed(futures):
-            titulo = futures[future]
             try:
-                future.result()
-                logs.append({"type": "success", "message": f" Mensagem enviada para {titulo}"})
+                enviar_whatsapp(numero, mensagem_final.strip(), equipe_normalizada)
+                logs.append(
+                    {"type": "success", "message": f" Mensagem enviada para {titulo}"}
+                )
                 stats["sucesso"] += 1
             except Exception as e:
-                logs.append({"type": "error", "message": f" Erro ao enviar para {titulo}: {str(e)}"})
+                logs.append(
+                    {
+                        "type": "error",
+                        "message": f" Erro ao enviar para {titulo}: {str(e)}",
+                    }
+                )
                 stats["erro"] += 1
+
+            stats["total"] += 1
+            stats["equipes"].add(equipe_normalizada)
+            time.sleep(0.3)
 
     else:
         mensagens_por_grupo = gerar_mensagens(df, tipo_relatorio)
@@ -85,61 +89,63 @@ def processar_csv(caminho_csv, ignorar_sabados, tipo_relatorio, equipes_selecion
             equipe = equipe_match.iloc[0]
             mensagens_por_equipe_data[equipe][data].append(mensagem)
 
-        futures = {}
-        with ThreadPoolExecutor(max_workers=5) as executor:
-            for equipe, datas in sorted(mensagens_por_equipe_data.items()):
-                equipe_normalizada = str(equipe).strip().upper()
-                if equipes_selecionadas:
-                    equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
-                    if equipe_normalizada not in equipes_normalizadas:
-                        continue
-
-                numero = numero_equipe.get(equipe_normalizada)
-                if not numero or numero.strip().lower() in ["nan", "none", ""]:
-                    equipes_sem_numero.append(equipe)
-                    stats["erro"] += 1
+        for equipe, datas in sorted(mensagens_por_equipe_data.items()):
+            equipe_normalizada = str(equipe).strip().upper()
+            if equipes_selecionadas:
+                equipes_normalizadas = {e.strip().upper() for e in equipes_selecionadas}
+                if equipe_normalizada not in equipes_normalizadas:
                     continue
 
-                mensagens_sub = datas
-                datas_sub = defaultdict(list)
+            numero = numero_equipe.get(equipe_normalizada)
+            if not numero or numero.strip().lower() in ["nan", "none", ""]:
+                equipes_sem_numero.append(equipe)
+                stats["erro"] += 1
+                continue
 
-                for data, mensagens in mensagens_sub.items():
-                    mensagens_validas = [m for m in mensagens if m and isinstance(m, str)]
-                    if mensagens_validas:
-                        datas_sub[data].extend(mensagens_validas)
+            mensagens_sub = datas
+            datas_sub = defaultdict(list)
 
-                if not datas_sub:
+            for data, mensagens in mensagens_sub.items():
+                mensagens_validas = [m for m in mensagens if m and isinstance(m, str)]
+                if mensagens_validas:
+                    datas_sub[data].extend(mensagens_validas)
+
+            if not datas_sub:
+                continue
+
+            equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
+            titulo = f"LOJA {equipe}" if eh_loja(equipe_original) else f"{equipe}"
+            mensagem_final = f"*{titulo}*\n\n"
+
+            for data in sorted(
+                datas_sub.keys(), key=lambda d: datetime.strptime(d, "%d/%m/%Y")
+            ):
+                mensagens_validas = [m.strip() for m in datas_sub[data] if m and m.strip()]
+                if not mensagens_validas:
                     continue
+                mensagem_final += f"*NO DIA {data}:*\n"
+                for m in mensagens_validas:
+                    mensagem_final += f"• {m}\n"
+                mensagem_final += "\n"
 
-                equipe_original = df[df["EquipeTratada"] == equipe_normalizada]["Equipe"].iloc[0]
-                titulo = f"LOJA {equipe}" if eh_loja(equipe_original) else f"{equipe}"
-                mensagem_final = f"*{titulo}*\n\n"
-
-                for data in sorted(datas_sub.keys(), key=lambda d: datetime.strptime(d, "%d/%m/%Y")):
-                    mensagens_validas = [m.strip() for m in datas_sub[data] if m and m.strip()]
-                    if not mensagens_validas:
-                        continue
-                    mensagem_final += f"*NO DIA {data}:*\n"
-                    for m in mensagens_validas:
-                        mensagem_final += f"• {m}\n"
-                    mensagem_final += "\n"
-
-                future = executor.submit(
-                    enviar_whatsapp, numero, mensagem_final.strip(), equipe
-                )
-                futures[future] = titulo
-                stats["total"] += 1
-                stats["equipes"].add(equipe)
-
-        for future in as_completed(futures):
-            titulo = futures[future]
             try:
-                future.result()
-                logs.append({"type": "success", "message": f" Mensagem enviada para {titulo}"})
+                enviar_whatsapp(numero, mensagem_final.strip(), equipe)
+                logs.append(
+                    {"type": "success", "message": f" Mensagem enviada para {titulo}"}
+                )
                 stats["sucesso"] += 1
             except Exception as e:
-                logs.append({"type": "error", "message": f" Erro ao enviar para {titulo}: {str(e)}"})
+                logs.append(
+                    {
+                        "type": "error",
+                        "message": f" Erro ao enviar para {titulo}: {str(e)}",
+                    }
+                )
                 stats["erro"] += 1
+
+            stats["total"] += 1
+            stats["equipes"].add(equipe)
+            time.sleep(0.3)
 
     if equipes_sem_numero:
         logs.append({"type": "warning", "message": f" Números não encontrados para: {', '.join(equipes_sem_numero)}"})

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 from app.controller import processar_csv
 
-# Executor global por processo
-_executor = ThreadPoolExecutor(max_workers=4)
+# Executor global para evitar concorrência entre relatórios
+_executor = ThreadPoolExecutor(max_workers=1)
 _tasks = {}
 
 


### PR DESCRIPTION
## Summary
- reduzir intervalo entre envios para cerca de 300ms
- limitar executor de tarefas a uma única thread para evitar envios concorrentes

## Testing
- `flake8` *(falhou: command not found; instalação bloqueada)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af170065188333ad287a0a8b6e1964