### PR TITLE
Centralizar definição da URL base da API

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,15 +195,13 @@ server {
 
 #### URL base da API
 
-Defina a URL usada pelos scripts do frontend via meta tag ou variável global:
+A URL base da API é definida uma única vez na interface web e reutilizada pelos scripts:
 
 ```html
-<meta name="api-base-url" content="https://api.exemplo.com">
-<!-- ou -->
-<script>window.API_BASE_URL = 'https://api.exemplo.com';</script>
+<script>window.API_BASE_URL = window.location.origin;</script>
 ```
 
-Se nada for informado, o mesmo domínio da página será utilizado.
+Altere esse valor caso a API esteja em outro domínio.
 
 ## Uso
 

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -5,8 +5,8 @@ import {
     categorizarErro
 } from './mapear-erro.js';
 
-// URL base da API, obtida via meta tag ou variável global
-const API_BASE_URL = "http://192.168.99.50:8000";
+// URL base da API, definida globalmente
+const API_BASE_URL = window.API_BASE_URL;
 
 /**
  * Envia CSV para processamento no servidor

--- a/static/js/eventos.js
+++ b/static/js/eventos.js
@@ -3,11 +3,8 @@ import { enviarCSV, obterStatus } from './api.js';
 import { mostrarLogs, atualizarEstatisticas, mostrarDebug, atualizarBarraProgresso } from './ui.js';
 import { carregarDropdownEquipes } from './dropdown.js';
 
-// URL base da API, obtida via meta tag ou variável global
-const API_BASE_URL =
-    document.querySelector('meta[name="api-base-url"]')?.content ||
-    window.API_BASE_URL ||
-    '';
+// URL base da API definida globalmente
+const API_BASE_URL = window.API_BASE_URL;
 
 let arquivoInput = document.getElementById('csvFile');
 let arquivoSelecionado = null;  // Arquivo mantido em memória

--- a/static/js/whatsapp.js
+++ b/static/js/whatsapp.js
@@ -1,7 +1,7 @@
 // Controle de timeout para requisições
 const REQUEST_TIMEOUT = 10000; // 10 segundos
 
-const API_BASE_URL = "http://192.168.99.50:8000";
+const API_BASE_URL = window.API_BASE_URL;
 
 function createRequestWithTimeout(url, options = {}) {
     const controller = new AbortController();

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TopFama | Diparador de Mensagens PontoMais</title>
-    <!-- Variável global -->
+    <!-- URL base da API definida uma única vez -->
     <script>
-        window.API_BASE_URL = '192.168.99.50:8000';
+        window.API_BASE_URL = window.location.origin;
     </script>
 
 


### PR DESCRIPTION
## Summary
- definir `window.API_BASE_URL` automaticamente a partir de `window.location.origin`
- reutilizar `API_BASE_URL` global em todos os módulos JS
- ajustar documentação sobre configuração da URL da API

## Testing
- `pytest`
- `flake8` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bf1b4582c4833385563ce924ba0133