### PR TITLE
feat: diferenciar URLs internas e externas da API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# URL base da Evolution API (externa)
 EVOLUTION_URL=http://localhost:8080
 EVOLUTION_INSTANCE=seu-instance
 EVOLUTION_TOKEN=seu-token

--- a/README.md
+++ b/README.md
@@ -193,15 +193,14 @@ server {
 ```
 </details>
 
-#### URL base da API
+#### URLs da aplicação
 
-A URL base da API é definida uma única vez na interface web e reutilizada pelos scripts:
-
-```html
-<script>window.API_BASE_URL = window.location.origin;</script>
-```
-
-Altere esse valor caso a API esteja em outro domínio.
+- **API interna**: o frontend usa automaticamente `window.location.origin` para
+  conversar com o backend Flask. Dessa forma, a mesma URL acessada no
+  navegador é reutilizada nas requisições.
+- **EVOLUTION_URL**: variável de ambiente que aponta para a Evolution API
+  externa, responsável pelo envio das mensagens de WhatsApp. Defina esse valor
+  no arquivo `.env`.
 
 ## Uso
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
-EVOLUTION_URL = os.getenv("EVOLUTION_URL", "")
+# Base externa para chamadas à Evolution API
+EVOLUTION_URL = os.getenv("EVOLUTION_URL", "").rstrip("/")
 EVOLUTION_INSTANCE = os.getenv("EVOLUTION_INSTANCE", "")
 EVOLUTION_TOKEN = os.getenv("EVOLUTION_TOKEN", "")

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 import requests
+from urllib.parse import urljoin
 from app.processamento.mapear_gerencia import mapear_equipe
 from app.processamento.csv_reader import carregar_dados
 from app.tasks import enqueue_csv_processing, get_task_status
@@ -150,7 +151,7 @@ def well_known(subpath):
 @api_bp.route('/whatsapp/status', methods=['GET'])
 def whatsapp_status():
     try:
-        url = f"{EVOLUTION_URL}/instance/connectionState/{EVOLUTION_INSTANCE}"
+        url = urljoin(EVOLUTION_URL, f"/instance/connectionState/{EVOLUTION_INSTANCE}")
         resp = requests.get(url, headers=_evo_headers(), timeout=30)
         return jsonify(resp.json()), resp.status_code
     except Exception as exc:  # noqa: BLE001
@@ -161,7 +162,7 @@ def whatsapp_status():
 @api_bp.route('/whatsapp/qr', methods=['GET'])
 def whatsapp_qr():
     try:
-        url = f"{EVOLUTION_URL}/instance/connect/{EVOLUTION_INSTANCE}"
+        url = urljoin(EVOLUTION_URL, f"/instance/connect/{EVOLUTION_INSTANCE}")
         resp = requests.get(url, headers=_evo_headers(), timeout=30)
         return jsonify(resp.json()), resp.status_code
     except Exception as exc:  # noqa: BLE001
@@ -172,7 +173,10 @@ def whatsapp_qr():
 @api_bp.route('/whatsapp/instance', methods=['GET'])
 def whatsapp_instance():
     try:
-        url = f"{EVOLUTION_URL}/instance/fetchInstances?instanceName={EVOLUTION_INSTANCE}"
+        url = urljoin(
+            EVOLUTION_URL,
+            f"/instance/fetchInstances?instanceName={EVOLUTION_INSTANCE}",
+        )
         resp = requests.get(url, headers=_evo_headers(), timeout=30)
         return jsonify(resp.json()), resp.status_code
     except Exception as exc:  # noqa: BLE001
@@ -183,7 +187,7 @@ def whatsapp_instance():
 @api_bp.route('/whatsapp/logout', methods=['DELETE'])
 def whatsapp_logout():
     try:
-        url = f"{EVOLUTION_URL}/instance/logout/{EVOLUTION_INSTANCE}"
+        url = urljoin(EVOLUTION_URL, f"/instance/logout/{EVOLUTION_INSTANCE}")
         resp = requests.delete(url, headers=_evo_headers(), timeout=30)
         return jsonify(resp.json()), resp.status_code
     except Exception as exc:  # noqa: BLE001

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -5,8 +5,8 @@ import {
     categorizarErro
 } from './mapear-erro.js';
 
-// URL base da API, definida globalmente
-const API_BASE_URL = window.API_BASE_URL;
+// URL base da API interna (origem atual)
+const API_BASE_URL = window.location.origin;
 
 /**
  * Envia CSV para processamento no servidor

--- a/static/js/eventos.js
+++ b/static/js/eventos.js
@@ -3,8 +3,8 @@ import { enviarCSV, obterStatus } from './api.js';
 import { mostrarLogs, atualizarEstatisticas, mostrarDebug, atualizarBarraProgresso } from './ui.js';
 import { carregarDropdownEquipes } from './dropdown.js';
 
-// URL base da API definida globalmente
-const API_BASE_URL = window.API_BASE_URL;
+// URL base da API interna (origem atual)
+const API_BASE_URL = window.location.origin;
 
 let arquivoInput = document.getElementById('csvFile');
 let arquivoSelecionado = null;  // Arquivo mantido em memória

--- a/static/js/whatsapp.js
+++ b/static/js/whatsapp.js
@@ -1,7 +1,7 @@
 // Controle de timeout para requisições
 const REQUEST_TIMEOUT = 10000; // 10 segundos
 
-const API_BASE_URL = window.API_BASE_URL;
+const API_BASE_URL = window.location.origin;
 
 function createRequestWithTimeout(url, options = {}) {
     const controller = new AbortController();

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,12 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TopFama | Diparador de Mensagens PontoMais</title>
-    <!-- URL base da API definida uma única vez -->
-    <script>
-        window.API_BASE_URL = window.location.origin;
-    </script>
-
-
     <!-- CSS Modularizado -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/header.css') }}">


### PR DESCRIPTION
## Sumário
- separa base interna e externa da API
- documenta URLs internas e externas

## Testes
- `flake8` *(falhou: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c0650bb1508333910db5f83e4e4bff