### PR TITLE
fix: interpretar log de erro como texto

### DIFF
--- a/static/js/mapear-erro.js
+++ b/static/js/mapear-erro.js
@@ -126,10 +126,18 @@ export async function processarRespostaHTTP(response) {
             // Prioriza mensagens do log do servidor (Flask)
             if (errorData.log && Array.isArray(errorData.log) && errorData.log.length > 0) {
                 const mensagensServidor = errorData.log
-                    .filter(entry => entry.type === 'error')
-                    .map(entry => entry.message.replace(/^❌\s*/, '')) // Remove emoji duplicado
+                    .map(entry => {
+                        if (typeof entry === 'string') {
+                            return entry.replace(/^❌\s*/, '');
+                        }
+                        if (entry.type === 'error') {
+                            return entry.message.replace(/^❌\s*/, '');
+                        }
+                        return null;
+                    })
+                    .filter(Boolean)
                     .join(', ');
-                
+
                 if (mensagensServidor) {
                     return `${mensagensServidor}`;
                 }


### PR DESCRIPTION
## Summary
- permitir que mensagens de log em formato de texto sejam exibidas em erros HTTP

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c08d6b719c833387082f46e8efc719