### PR TITLE
feat: adicionar página de histórico de envios

### DIFF
--- a/app/history.py
+++ b/app/history.py
@@ -1,0 +1,71 @@
+"""Módulo para armazenamento e consulta do histórico de envios."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+
+# Caminho do banco de dados SQLite
+DB_PATH = Path(__file__).resolve().parent.parent / "historico.db"
+
+
+def init_db() -> None:
+    """Cria a tabela de histórico caso não exista."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            (
+                "CREATE TABLE IF NOT EXISTS envios ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                "data_envio TEXT NOT NULL,"
+                "equipe TEXT NOT NULL,"
+                "tipo_relatorio TEXT NOT NULL,"
+                "status TEXT NOT NULL"
+                ")"
+            )
+        )
+        conn.commit()
+
+
+def registrar_envio(equipe: str, tipo_relatorio: str, status: str) -> None:
+    """Registra um envio na base de dados."""
+    init_db()
+    data_envio = datetime.utcnow().isoformat()
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO envios (data_envio, equipe, tipo_relatorio, status) VALUES (?, ?, ?, ?)",
+            (data_envio, equipe, tipo_relatorio, status),
+        )
+        conn.commit()
+
+
+def listar_envios(
+    equipe: Optional[str] = None,
+    tipo: Optional[str] = None,
+    inicio: Optional[str] = None,
+    fim: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Retorna uma lista de envios aplicando filtros quando informados."""
+    init_db()
+    query = [
+        "SELECT data_envio, equipe, tipo_relatorio, status FROM envios WHERE 1=1"
+    ]
+    params: List[str] = []
+    if equipe:
+        query.append("AND equipe = ?")
+        params.append(equipe)
+    if tipo:
+        query.append("AND tipo_relatorio = ?")
+        params.append(tipo)
+    if inicio:
+        query.append("AND date(data_envio) >= date(?)")
+        params.append(inicio)
+    if fim:
+        query.append("AND date(data_envio) <= date(?)")
+        params.append(fim)
+    query.append("ORDER BY data_envio DESC")
+    sql = " ".join(query)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [dict(row) for row in rows]

--- a/app/routes.py
+++ b/app/routes.py
@@ -15,6 +15,7 @@ from app.config.settings import (
     EVOLUTION_TOKEN,
     EVOLUTION_URL,
 )
+from app.history import listar_envios
 
 api_bp = Blueprint('api', __name__)
 UPLOAD_FOLDER = 'uploads'
@@ -298,3 +299,14 @@ def whatsapp_logout():
     except Exception as exc:  # noqa: BLE001
         logging.exception("Erro ao desconectar WhatsApp")
         return jsonify({"error": str(exc)}), 500
+
+
+@api_bp.route('/historico/dados', methods=['GET'])
+def historico_envios():
+    """Retorna o histórico de envios com filtros opcionais."""
+    equipe = request.args.get('equipe')
+    tipo = request.args.get('tipo')
+    inicio = request.args.get('inicio')
+    fim = request.args.get('fim')
+    dados = listar_envios(equipe=equipe, tipo=tipo, inicio=inicio, fim=fim)
+    return jsonify({"success": True, "dados": dados})

--- a/main.py
+++ b/main.py
@@ -13,5 +13,11 @@ app.register_blueprint(api_bp)
 def index():
     return render_template('index.html')
 
+
+@app.route('/historico')
+def historico():
+    """Página que exibe o histórico de envios."""
+    return render_template('historico.html')
+
 if __name__ == '__main__':    
     app.run(use_reloader=False, host="0.0.0.0", port=8000)

--- a/static/css/whatsapp-status.css
+++ b/static/css/whatsapp-status.css
@@ -174,3 +174,51 @@
     font-size: 14px;
 }
 
+/* ===== SEÇÃO DE HISTÓRICO ===== */
+.history-section {
+    margin-top: 16px;
+    transition: all 0.3s ease;
+}
+
+.history-section.hidden {
+    display: none;
+}
+
+.history-button {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #4B5563, #374151);
+    color: white;
+    border: none;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 8px rgba(55, 65, 81, 0.2);
+}
+
+.history-button:hover {
+    background: linear-gradient(135deg, #374151, #1F2937);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(55, 65, 81, 0.3);
+}
+
+.history-button:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 6px rgba(55, 65, 81, 0.2);
+}
+
+.history-icon {
+    font-size: 16px;
+}
+
+.history-text {
+    font-size: 14px;
+}
+

--- a/static/js/historico.js
+++ b/static/js/historico.js
@@ -1,0 +1,71 @@
+async function carregarDados() {
+  const params = new URLSearchParams();
+  const equipe = document.getElementById('filtroEquipe').value;
+  const tipo = document.getElementById('filtroTipo').value;
+  const inicio = document.getElementById('filtroInicio').value;
+  const fim = document.getElementById('filtroFim').value;
+  if (equipe) params.append('equipe', equipe);
+  if (tipo) params.append('tipo', tipo);
+  if (inicio) params.append('inicio', inicio);
+  if (fim) params.append('fim', fim);
+  const resp = await fetch(`/historico/dados?${params.toString()}`);
+  const data = await resp.json();
+  if (!data.success) return;
+  preencherTabela(data.dados);
+  atualizarEquipeSelect(data.dados);
+  atualizarGrafico(data.dados);
+}
+
+function preencherTabela(dados) {
+  const tbody = document.querySelector('#tabelaEnvios tbody');
+  tbody.innerHTML = '';
+  for (const row of dados) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${row.data_envio}</td><td>${row.equipe}</td><td>${row.tipo_relatorio}</td><td>${row.status}</td>`;
+    tbody.appendChild(tr);
+  }
+}
+
+let grafico;
+function atualizarGrafico(dados) {
+  const ctx = document.getElementById('graficoStatus').getContext('2d');
+  const contagem = dados.reduce((acc, item) => {
+    acc[item.status] = (acc[item.status] || 0) + 1;
+    return acc;
+  }, {});
+  const labels = Object.keys(contagem);
+  const valores = Object.values(contagem);
+  if (grafico) grafico.destroy();
+  grafico = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Envios',
+        data: valores,
+        backgroundColor: '#4CAF50'
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+}
+
+function atualizarEquipeSelect(dados) {
+  const select = document.getElementById('filtroEquipe');
+  const equipes = [...new Set(dados.map((d) => d.equipe))].sort();
+  const atual = select.value;
+  select.innerHTML = '<option value="">Todas</option>';
+  for (const eq of equipes) {
+    const opt = document.createElement('option');
+    opt.value = eq;
+    opt.textContent = eq;
+    if (eq === atual) opt.selected = true;
+    select.appendChild(opt);
+  }
+}
+
+document.getElementById('aplicarFiltros').addEventListener('click', carregarDados);
+window.addEventListener('load', carregarDados);

--- a/static/js/whatsapp.js
+++ b/static/js/whatsapp.js
@@ -24,6 +24,7 @@ export async function verificarStatusWhatsapp() {
     const mainContent = document.getElementById('mainContent');
     const connectionMessage = document.getElementById('connectionMessage');
     const logoutSection = document.getElementById('logoutSection');
+    const historySection = document.getElementById('historySection');
 
     try {
         // Consulta o status da conexão
@@ -52,6 +53,7 @@ export async function verificarStatusWhatsapp() {
             mainContent.classList.add('hidden');
             connectionMessage.classList.remove('hidden');
             logoutSection.classList.add('hidden');
+            historySection.classList.add('hidden');
 
             // NÃO fazer reconexão automática - deixar manual
             return "CLOSE";
@@ -66,7 +68,7 @@ export async function verificarStatusWhatsapp() {
             try {
                 const qrRes = await createRequestWithTimeout(`${API_BASE_URL}/whatsapp/qr`);
                 const qrData = await qrRes.json();
-                
+
                 if (qrData.base64) {
                     qrImage.src = qrData.base64;
                     qrImage.style.display = "block";
@@ -74,7 +76,7 @@ export async function verificarStatusWhatsapp() {
                 } else {
                     console.warn("QR Code não encontrado na resposta.", qrData);
                 }
-                
+
             } catch (qrError) {
                 console.error("Erro ao obter QR Code:", qrError);
             }
@@ -82,6 +84,7 @@ export async function verificarStatusWhatsapp() {
             mainContent.classList.add('hidden');
             connectionMessage.classList.remove('hidden');
             logoutSection.classList.add('hidden');
+            historySection.classList.add('hidden');
 
             // console.log("🟢 QR Code solicitado");
             return "CONNECTING";
@@ -129,6 +132,7 @@ export async function verificarStatusWhatsapp() {
             mainContent.classList.remove('hidden');
             connectionMessage.classList.add('hidden');
             logoutSection.classList.remove('hidden');
+            historySection.classList.remove('hidden');
             return "OPEN";
         }
 
@@ -144,6 +148,7 @@ export async function verificarStatusWhatsapp() {
             mainContent.classList.add('hidden');
             connectionMessage.classList.remove('hidden');
             logoutSection.classList.add('hidden');
+            historySection.classList.add('hidden');
 
             return "ESTADO DESCONHECIDO: " +state;
         }
@@ -160,6 +165,7 @@ export async function verificarStatusWhatsapp() {
         mainContent.classList.add('hidden');
         connectionMessage.classList.remove('hidden');
         logoutSection.classList.add('hidden');
+        historySection.classList.add('hidden');
 
         return "ERROR";
     }

--- a/templates/historico.html
+++ b/templates/historico.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Histórico de Envios</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main-content.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Histórico de Envios</h1>
+        </div>
+        <div class="content">
+            <div class="card">
+                <h3>Filtros</h3>
+                <div class="filters">
+                    <label>Equipe:
+                        <select id="filtroEquipe">
+                            <option value="">Todas</option>
+                        </select>
+                    </label>
+                    <label>Tipo:
+                        <select id="filtroTipo">
+                            <option value="">Todos</option>
+                            <option value="Auditoria">Auditoria</option>
+                            <option value="Assinaturas">Assinaturas</option>
+                            <option value="Ocorrências">Ocorrências</option>
+                        </select>
+                    </label>
+                    <label>De:
+                        <input type="date" id="filtroInicio">
+                    </label>
+                    <label>Até:
+                        <input type="date" id="filtroFim">
+                    </label>
+                    <button id="aplicarFiltros">Filtrar</button>
+                </div>
+            </div>
+
+            <div class="card">
+                <h3>Resumo por Status</h3>
+                <canvas id="graficoStatus"></canvas>
+            </div>
+
+            <div class="card">
+                <h3>Registros</h3>
+                <table id="tabelaEnvios">
+                    <thead>
+                        <tr>
+                            <th>Data</th>
+                            <th>Equipe</th>
+                            <th>Tipo</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="module" src="{{ url_for('static', filename='js/historico.js') }}"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -49,10 +49,18 @@
                         <span class="logout-text">Desconectar WhatsApp</span>
                     </button>
                 </div>
-                
+
+                <!-- Link para histórico (visível apenas quando conectado) -->
+                <div id="historySection" class="history-section hidden">
+                    <a href="{{ url_for('historico') }}" class="history-button">
+                        <span class="history-icon">📜</span>
+                        <span class="history-text">Histórico de envios</span>
+                    </a>
+                </div>
+
                 <!-- QR Code Section -->
                 <div id="qrContainer" class="qr-section">
-                    <div class="qr-overlay" > </div>     
+                    <div class="qr-overlay" > </div>
                     <div class="qr-frame">
                         
                         <img id="qrImage" class="qr-code" src="" alt="QR Code">


### PR DESCRIPTION
## Resumo
- registrar envios em banco SQLite
- criar página com filtros e gráficos para visualizar histórico
- expor endpoint de histórico para consumo via dashboard
- exibir link para histórico quando o WhatsApp estiver conectado

## Testes
- `pytest`
- `pip install flake8` (falhou: Could not find a version that satisfies the requirement flake8)
- `flake8` (falhou: command not found)


------
https://chatgpt.com/codex/tasks/task_b_68c2e2993e648333bf384095f6fbbf06