### PR TITLE
feat: aplicar novo visual à página de histórico

### DIFF
--- a/static/css/historico.css
+++ b/static/css/historico.css
@@ -1,0 +1,428 @@
+/* Estilos para a página de histórico */
+
+/* Base styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+    color: #333;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+.header {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 20px;
+    padding: 30px;
+    margin-bottom: 30px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(10px);
+    text-align: center;
+}
+
+.header h1 {
+    color: #2c3e50;
+    font-size: 2.5rem;
+    font-weight: 700;
+    margin-bottom: 10px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.header p {
+    color: #7f8c8d;
+    font-size: 1.1rem;
+    font-weight: 400;
+}
+
+/* Cards */
+.card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 20px;
+    padding: 25px;
+    margin-bottom: 25px;
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(10px);
+    transition: all 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
+}
+
+.card h3 {
+    color: #2c3e50;
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* Counter card */
+.counter-card {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    text-align: center;
+}
+
+.counter-card h3 {
+    color: white;
+    font-size: 1.5rem;
+    margin-bottom: 15px;
+}
+
+.counter-number {
+    font-size: 3rem;
+    font-weight: 700;
+    margin-bottom: 10px;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.counter-label {
+    font-size: 1.1rem;
+    opacity: 0.9;
+    font-weight: 500;
+}
+
+.counter-breakdown {
+    display: flex;
+    justify-content: center;
+    gap: 30px;
+    margin-top: 20px;
+    font-size: 0.9rem;
+}
+
+.breakdown-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.breakdown-item .success {
+    color: #2ecc71;
+}
+
+.breakdown-item .error {
+    color: #e74c3c;
+}
+
+/* Filters */
+.filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.filter-group label {
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 0.9rem;
+}
+
+/* Custom Dropdown */
+.custom-dropdown {
+    position: relative;
+}
+
+.dropdown-header {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 12px 15px;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: all 0.3s ease;
+    font-size: 0.9rem;
+}
+
+.dropdown-header:hover {
+    border-color: #667eea;
+    background: #fff;
+}
+
+.dropdown-header.active {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.dropdown-arrow {
+    transition: transform 0.3s ease;
+    color: #6c757d;
+}
+
+.dropdown-header.active .dropdown-arrow {
+    transform: rotate(180deg);
+}
+
+.dropdown-content {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 2px solid #667eea;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    max-height: 200px;
+    overflow-y: auto;
+    display: none;
+    margin-top: 5px;
+}
+
+.dropdown-content.show {
+    display: block;
+    animation: dropdownSlide 0.3s ease;
+}
+
+@keyframes dropdownSlide {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.dropdown-item {
+    padding: 12px 15px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    font-size: 0.9rem;
+}
+
+.dropdown-item:hover {
+    background: #f8f9fa;
+}
+
+.dropdown-item.selected {
+    background: #667eea;
+    color: white;
+}
+
+/* Date inputs */
+.date-input {
+    background: #f8f9fa;
+    border: 2px solid #e9ecef;
+    border-radius: 12px;
+    padding: 12px 15px;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+}
+
+.date-input:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    background: white;
+}
+
+/* Filter button */
+.filter-button {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 12px 25px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+}
+
+.filter-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+}
+
+.filter-button:active {
+    transform: translateY(0);
+}
+
+/* Chart container */
+.chart-container {
+    position: relative;
+    height: 400px;
+    margin: 20px 0;
+    padding: 20px;
+    background: #f8f9fa;
+    border-radius: 12px;
+}
+
+/* Table */
+.table-container {
+    overflow-x: auto;
+    border-radius: 12px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background: white;
+}
+
+table th {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    padding: 15px;
+    text-align: left;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+table th:first-child {
+    border-top-left-radius: 12px;
+}
+
+table th:last-child {
+    border-top-right-radius: 12px;
+}
+
+table td {
+    padding: 12px 15px;
+    border-bottom: 1px solid #e9ecef;
+    font-size: 0.9rem;
+}
+
+table tbody tr:hover {
+    background: #f8f9fa;
+}
+
+table tbody tr:last-child td:first-child {
+    border-bottom-left-radius: 12px;
+}
+
+table tbody tr:last-child td:last-child {
+    border-bottom-right-radius: 12px;
+}
+
+.status-badge {
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.status-success {
+    background: #d4edda;
+    color: #155724;
+}
+
+.status-error {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+/* Loading state */
+.loading {
+    text-align: center;
+    padding: 40px;
+    color: #6c757d;
+}
+
+.loading-spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #667eea;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 20px;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+/* Back button */
+.back-button {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 2px solid #667eea;
+    border-radius: 50px;
+    padding: 12px 20px;
+    text-decoration: none;
+    color: #667eea;
+    font-weight: 600;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+    z-index: 1000;
+}
+
+.back-button:hover {
+    background: #667eea;
+    color: white;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .container {
+        padding: 15px;
+    }
+
+    .header h1 {
+        font-size: 2rem;
+    }
+
+    .filters {
+        grid-template-columns: 1fr;
+    }
+
+    .counter-breakdown {
+        flex-direction: column;
+        gap: 15px;
+    }
+
+    .chart-container {
+        height: 300px;
+    }
+
+    .back-button {
+        position: relative;
+        top: auto;
+        left: auto;
+        margin-bottom: 20px;
+        display: block;
+        text-align: center;
+    }
+}
+

--- a/static/js/historico.js
+++ b/static/js/historico.js
@@ -1,79 +1,249 @@
+let graficoPorEquipe;
+let dados = [];
+
+// Configurar dropdowns
+function setupDropdowns() {
+  // Dropdown de Equipe
+  const equipeHeader = document.getElementById('equipeDropdownHeader');
+  const equipeContent = document.getElementById('equipeDropdownContent');
+  const equipeSelected = document.getElementById('equipeSelectedText');
+  const equipeInput = document.getElementById('filtroEquipe');
+
+  equipeHeader.addEventListener('click', () => {
+    equipeHeader.classList.toggle('active');
+    equipeContent.classList.toggle('show');
+  });
+
+  equipeContent.addEventListener('click', (e) => {
+    if (e.target.classList.contains('dropdown-item')) {
+      document
+        .querySelectorAll('#equipeDropdownContent .dropdown-item')
+        .forEach((item) => {
+          item.classList.remove('selected');
+        });
+      e.target.classList.add('selected');
+      equipeSelected.textContent = e.target.textContent;
+      equipeInput.value = e.target.getAttribute('data-value');
+      equipeHeader.classList.remove('active');
+      equipeContent.classList.remove('show');
+    }
+  });
+
+  // Dropdown de Tipo
+  const tipoHeader = document.getElementById('tipoDropdownHeader');
+  const tipoContent = document.getElementById('tipoDropdownContent');
+  const tipoSelected = document.getElementById('tipoSelectedText');
+  const tipoInput = document.getElementById('filtroTipo');
+
+  tipoHeader.addEventListener('click', () => {
+    tipoHeader.classList.toggle('active');
+    tipoContent.classList.toggle('show');
+  });
+
+  tipoContent.addEventListener('click', (e) => {
+    if (e.target.classList.contains('dropdown-item')) {
+      document
+        .querySelectorAll('#tipoDropdownContent .dropdown-item')
+        .forEach((item) => {
+          item.classList.remove('selected');
+        });
+      e.target.classList.add('selected');
+      tipoSelected.textContent = e.target.textContent;
+      tipoInput.value = e.target.getAttribute('data-value');
+      tipoHeader.classList.remove('active');
+      tipoContent.classList.remove('show');
+    }
+  });
+
+  // Fechar dropdowns ao clicar fora
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('.custom-dropdown')) {
+      document.querySelectorAll('.dropdown-header').forEach((header) => {
+        header.classList.remove('active');
+      });
+      document.querySelectorAll('.dropdown-content').forEach((content) => {
+        content.classList.remove('show');
+      });
+    }
+  });
+}
+
+// Carregar dados
 async function carregarDados() {
+  const loadingIndicator = document.getElementById('loadingIndicator');
+  loadingIndicator.style.display = 'block';
+
   const params = new URLSearchParams();
   const equipe = document.getElementById('filtroEquipe').value;
   const tipo = document.getElementById('filtroTipo').value;
   const inicio = document.getElementById('filtroInicio').value;
   const fim = document.getElementById('filtroFim').value;
+
   if (equipe) params.append('equipe', equipe);
   if (tipo) params.append('tipo', tipo);
   if (inicio) params.append('inicio', inicio);
   if (fim) params.append('fim', fim);
-  const resp = await fetch(`/historico/dados?${params.toString()}`);
-  const data = await resp.json();
-  if (!data.success) return;
-  preencherTabela(data.dados);
-  atualizarEquipeSelect(data.dados);
-  atualizarGrafico(data.dados);
+
+  try {
+    const resp = await fetch(`/historico/dados?${params.toString()}`);
+    const data = await resp.json();
+    if (data.success) {
+      dados = data.dados;
+      preencherTabela(dados);
+      atualizarEquipeSelect(dados);
+      atualizarContadores(dados);
+      atualizarGraficoEquipes(dados);
+    }
+  } catch (error) {
+    console.error('Erro ao carregar dados:', error);
+  } finally {
+    loadingIndicator.style.display = 'none';
+  }
 }
 
+// Preencher tabela
 function preencherTabela(dados) {
   const tbody = document.querySelector('#tabelaEnvios tbody');
   tbody.innerHTML = '';
-  for (const row of dados) {
+
+  dados.forEach((row) => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${row.data_envio}</td><td>${row.equipe}</td><td>${row.tipo_relatorio}</td><td>${row.status}</td>`;
-    tbody.appendChild(tr);
-  }
-}
-
-let grafico;
-function atualizarGrafico(dados) {
-  const ctx = document.getElementById('graficoStatus').getContext('2d');
-  const contagem = dados.reduce((acc, item) => {
-    acc[item.status] = (acc[item.status] || 0) + 1;
-    return acc;
-  }, {});
-  const labels = Object.keys(contagem);
-  const valores = Object.values(contagem);
-
-  if (grafico) {
-    grafico.data.labels = labels;
-    grafico.data.datasets[0].data = valores;
-    grafico.update();
-  } else {
-    grafico = new Chart(ctx, {
-      type: 'bar',
-      data: {
-        labels,
-        datasets: [{
-          label: 'Envios',
-          data: valores,
-          backgroundColor: '#4CAF50'
-        }]
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false
-      }
+    const dataFormatada = new Date(row.data_envio).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
-  }
-
+    const statusClass = row.status === 'sucesso' ? 'status-success' : 'status-error';
+    const statusIcon = row.status === 'sucesso' ? '✅' : '❌';
+    tr.innerHTML = `
+      <td>${dataFormatada}</td>
+      <td>${row.equipe}</td>
+      <td>${row.tipo_relatorio}</td>
+      <td><span class="status-badge ${statusClass}">${statusIcon} ${row.status}</span></td>
+    `;
+    tbody.appendChild(tr);
+  });
 }
 
+// Atualizar contadores
+function atualizarContadores(dados) {
+
+  const total = dados.length;
+  const sucessos = dados.filter((d) => d.status === 'sucesso').length;
+  const erros = dados.filter((d) => d.status === 'erro').length;
+
+  document.getElementById('totalCounter').textContent = total;
+  document.getElementById('successTotal').textContent = sucessos;
+  document.getElementById('errorTotal').textContent = erros;
+}
+
+// Atualizar dropdown de equipes
 function atualizarEquipeSelect(dados) {
-  const select = document.getElementById('filtroEquipe');
   const equipes = [...new Set(dados.map((d) => d.equipe))].sort();
-  const atual = select.value;
-  select.innerHTML = '<option value="">Todas</option>';
-  for (const eq of equipes) {
-    const opt = document.createElement('option');
-    opt.value = eq;
-    opt.textContent = eq;
-    if (eq === atual) opt.selected = true;
-    select.appendChild(opt);
-  }
+  const equipeContent = document.getElementById('equipeDropdownContent');
+  const currentValue = document.getElementById('filtroEquipe').value;
+
+  // Manter opção "Todas"
+  equipeContent.innerHTML = '<div class="dropdown-item selected" data-value="">Todas as equipes</div>';
+
+  equipes.forEach((equipe) => {
+    const item = document.createElement('div');
+    item.className = 'dropdown-item';
+    item.setAttribute('data-value', equipe);
+    item.textContent = equipe;
+    if (equipe === currentValue) {
+      item.classList.add('selected');
+      document.getElementById('equipeSelectedText').textContent = equipe;
+    }
+    equipeContent.appendChild(item);
+  });
 }
 
-document.getElementById('aplicarFiltros').addEventListener('click', carregarDados);
-carregarDados();
+// Atualizar gráfico por equipes
+function atualizarGraficoEquipes(dados) {
+  const ctx = document.getElementById('graficoEquipes').getContext('2d');
+
+  const equipeCounts = {};
+  dados.forEach((item) => {
+    if (!equipeCounts[item.equipe]) {
+      equipeCounts[item.equipe] = { sucesso: 0, erro: 0 };
+    }
+    equipeCounts[item.equipe][item.status]++;
+  });
+
+  const equipes = Object.keys(equipeCounts).sort();
+  const sucessos = equipes.map((eq) => equipeCounts[eq].sucesso || 0);
+  const erros = equipes.map((eq) => equipeCounts[eq].erro || 0);
+
+  if (graficoPorEquipe) {
+    graficoPorEquipe.destroy();
+  }
+
+  graficoPorEquipe = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: equipes,
+      datasets: [
+        {
+          label: 'Sucessos',
+          data: sucessos,
+          backgroundColor: 'rgba(46, 204, 113, 0.8)',
+          borderColor: 'rgba(46, 204, 113, 1)',
+          borderWidth: 2,
+          borderRadius: 8,
+        },
+        {
+          label: 'Falhas',
+          data: erros,
+          backgroundColor: 'rgba(231, 76, 60, 0.8)',
+          borderColor: 'rgba(231, 76, 60, 1)',
+          borderWidth: 2,
+          borderRadius: 8,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        title: {
+          display: true,
+          text: 'Envios por Equipe (Sucessos vs Falhas)',
+          font: { size: 16, weight: 'bold' },
+        },
+        legend: {
+          position: 'top',
+          labels: {
+            usePointStyle: true,
+            font: { size: 12, weight: '600' },
+          },
+        },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: { stepSize: 1 },
+          grid: { color: 'rgba(0, 0, 0, 0.1)' },
+        },
+        x: {
+          grid: { display: false },
+          ticks: { maxRotation: 45 },
+        },
+      },
+      interaction: { intersect: false, mode: 'index' },
+      animation: { duration: 1000, easing: 'easeOutQuart' },
+    },
+  });
+}
+
+// Inicializar
+document.addEventListener('DOMContentLoaded', () => {
+  setupDropdowns();
+  document
+    .getElementById('aplicarFiltros')
+    .addEventListener('click', carregarDados);
+  carregarDados();
+});
 

--- a/templates/historico.html
+++ b/templates/historico.html
@@ -3,52 +3,108 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Histórico de Envios</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/main-content.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <title>TopFama | Histórico de Envios</title>
+    <link rel="icon" href="https://lojastopfama.com.br/sobre/topfama_icon.png" type="image/png">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/historico.css') }}">
 </head>
 <body>
+    <a href="/" class="back-button">← Voltar ao Início</a>
+
     <div class="container">
+        <!-- Header -->
         <div class="header">
-            <h1>Histórico de Envios</h1>
+            <h1>📊 Histórico de Envios</h1>
+            <p>Acompanhe todos os envios de mensagens realizados pelo sistema</p>
         </div>
-        <div class="content">
-            <div class="card">
-                <h3>Filtros</h3>
-                <div class="filters">
-                    <label>Equipe:
-                        <select id="filtroEquipe">
-                            <option value="">Todas</option>
-                        </select>
-                    </label>
-                    <label>Tipo:
-                        <select id="filtroTipo">
-                            <option value="">Todos</option>
-                            <option value="Auditoria">Auditoria</option>
-                            <option value="Assinaturas">Assinaturas</option>
-                            <option value="Ocorrências">Ocorrências</option>
-                        </select>
-                    </label>
-                    <label>De:
-                        <input type="date" id="filtroInicio">
-                    </label>
-                    <label>Até:
-                        <input type="date" id="filtroFim">
-                    </label>
-                    <button id="aplicarFiltros">Filtrar</button>
+
+        <!-- Counter Card -->
+        <div class="card counter-card">
+            <h3>📈 Total Geral de Envios</h3>
+            <div class="counter-number" id="totalCounter">0</div>
+            <div class="counter-label">envios realizados</div>
+            <div class="counter-breakdown">
+                <div class="breakdown-item">
+                    <span class="success">✅</span>
+                    <span id="successTotal">0</span>
+                    <span>sucessos</span>
+                </div>
+                <div class="breakdown-item">
+                    <span class="error">❌</span>
+                    <span id="errorTotal">0</span>
+                    <span>falhas</span>
                 </div>
             </div>
+        </div>
 
-            <div class="card">
-                <h3>Resumo por Status</h3>
-                <div class="grafico-container">
-                    <canvas id="graficoStatus"></canvas>
+        <!-- Filters Card -->
+        <div class="card">
+            <h3>🔍 Filtros</h3>
+            <div class="filters">
+                <div class="filter-group">
+                    <label>Equipe:</label>
+                    <div class="custom-dropdown">
+                        <div class="dropdown-header" id="equipeDropdownHeader">
+                            <span id="equipeSelectedText">Todas as equipes</span>
+                            <span class="dropdown-arrow">▼</span>
+                        </div>
+                        <div class="dropdown-content" id="equipeDropdownContent">
+                            <div class="dropdown-item selected" data-value="">Todas as equipes</div>
+                        </div>
+                        <input type="hidden" id="filtroEquipe" value="">
+                    </div>
+                </div>
+
+                <div class="filter-group">
+                    <label>Tipo de Relatório:</label>
+                    <div class="custom-dropdown">
+                        <div class="dropdown-header" id="tipoDropdownHeader">
+                            <span id="tipoSelectedText">Todos os tipos</span>
+                            <span class="dropdown-arrow">▼</span>
+                        </div>
+                        <div class="dropdown-content" id="tipoDropdownContent">
+                            <div class="dropdown-item selected" data-value="">Todos os tipos</div>
+                            <div class="dropdown-item" data-value="Auditoria">🔍 Auditoria</div>
+                            <div class="dropdown-item" data-value="Assinaturas">📝 Assinaturas</div>
+                            <div class="dropdown-item" data-value="Ocorrências">⚠️ Ocorrências</div>
+                        </div>
+                        <input type="hidden" id="filtroTipo" value="">
+                    </div>
+                </div>
+
+                <div class="filter-group">
+                    <label>Data Inicial:</label>
+                    <input type="date" id="filtroInicio" class="date-input">
+                </div>
+
+                <div class="filter-group">
+                    <label>Data Final:</label>
+                    <input type="date" id="filtroFim" class="date-input">
+                </div>
+
+                <div class="filter-group" style="display: flex; align-items: end;">
+                    <button id="aplicarFiltros" class="filter-button">
+                        🔄 Aplicar Filtros
+                    </button>
                 </div>
             </div>
+        </div>
 
-            <div class="card">
-                <h3>Registros</h3>
+        <!-- Chart Card -->
+        <div class="card">
+            <h3>📊 Envios por Equipe</h3>
+            <div class="chart-container">
+                <canvas id="graficoEquipes"></canvas>
+            </div>
+        </div>
+
+        <!-- Table Card -->
+        <div class="card">
+            <h3>📋 Registros Detalhados</h3>
+            <div id="loadingIndicator" class="loading" style="display: none;">
+                <div class="loading-spinner"></div>
+                <p>Carregando dados...</p>
+            </div>
+            <div class="table-container">
                 <table id="tabelaEnvios">
                     <thead>
                         <tr>
@@ -63,7 +119,8 @@
             </div>
         </div>
     </div>
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script type="module" src="{{ url_for('static', filename='js/historico.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/historico.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Resumo
- aplica layout moderno com filtros, contadores e gráfico na página de histórico
- move estilos e scripts do histórico para arquivos dedicados

## Testes
- `flake8` *(falhou: comando não encontrado)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c31eabdfa88333a32dfe242b22e4a4