### PR TITLE
feat: adicionar resumo matricial interativo

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from app.whatsapp.numeros_equipes import carregar_numeros_equipes
 from app.processamento.log import configurar_log
 from app.processamento.mapear_gerencia import eh_loja
+from app.processamento.resumo_matricial import gerar_resumo_matricial
 from collections import defaultdict
 from datetime import datetime
 import logging
@@ -32,6 +33,7 @@ def processar_csv(caminho_csv, ignorar_sabados, tipo_relatorio, equipes_selecion
     df["EquipeTratada"] = df["EquipeTratada"].astype(str).str.strip().str.upper()
 
     numero_equipe = carregar_numeros_equipes()
+    resumo_matricial = gerar_resumo_matricial(df, tipo_relatorio)
 
     logs = []
     equipes_sem_numero = []
@@ -146,4 +148,4 @@ def processar_csv(caminho_csv, ignorar_sabados, tipo_relatorio, equipes_selecion
 
     stats["equipes"] = len(stats["equipes"])
     logging.info(">>> Finalizando processamento CSV. Total de equipes: %d", stats["total"])
-    return logs, stats, nome_arquivo_log
+    return logs, stats, nome_arquivo_log, resumo_matricial

--- a/app/processamento/resumo_matricial.py
+++ b/app/processamento/resumo_matricial.py
@@ -1,0 +1,100 @@
+"""Gera resumos matriciais com suporte a drill-down por pessoa."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pandas as pd
+
+
+_COLUNA_MOTIVO_POR_TIPO: Dict[str, str] = {
+    "Auditoria": "Ocorrência",
+    "Ocorrências": "Motivo",
+    "Assinaturas": "Período (Fechamento)",
+}
+
+
+def _normalizar_texto(valor: Any, padrao: str) -> str:
+    """Converte valores vazios em um texto padrão legível."""
+    if pd.isna(valor):
+        return padrao
+    texto = str(valor).strip()
+    return texto or padrao
+
+
+def gerar_resumo_matricial(df: pd.DataFrame, tipo_relatorio: str) -> List[Dict[str, Any]]:
+    """Cria um resumo matricial com drill-down por pessoa.
+
+    Retorna uma lista de dicionários com a estrutura::
+
+        {
+            "equipe": "Equipe",
+            "tipo_relatorio": "Auditoria",
+            "motivo": "Falta",
+            "qtd": 5,
+            "detalhes": [{"nome": "Maria", "qtd": 2}, ...]
+        }
+
+    O objetivo é alimentar a visualização interativa na interface, permitindo
+    explorar o total consolidado e os detalhes por pessoa (drill-down).
+    """
+    if df is None or df.empty:
+        return []
+
+    coluna_motivo = _COLUNA_MOTIVO_POR_TIPO.get(tipo_relatorio)
+    if not coluna_motivo or coluna_motivo not in df.columns:
+        return []
+
+    df_tratado = df.copy()
+
+    if "EquipeTratada" in df_tratado.columns:
+        equipe_base = df_tratado["EquipeTratada"]
+    elif "Equipe" in df_tratado.columns:
+        equipe_base = df_tratado["Equipe"]
+    else:
+        equipe_base = pd.Series([None] * len(df_tratado), index=df_tratado.index)
+
+    df_tratado["EquipeResumo"] = equipe_base.apply(
+        lambda valor: _normalizar_texto(valor, "Equipe não informada")
+    )
+
+    if "Nome" in df_tratado.columns:
+        pessoa_base = df_tratado["Nome"]
+    else:
+        pessoa_base = pd.Series([None] * len(df_tratado), index=df_tratado.index)
+
+    df_tratado["PessoaResumo"] = pessoa_base.apply(
+        lambda valor: _normalizar_texto(valor, "Colaborador não informado")
+    )
+
+    df_tratado["MotivoResumo"] = df_tratado[coluna_motivo].apply(
+        lambda valor: _normalizar_texto(valor, "Motivo não informado")
+    )
+
+    resumo: List[Dict[str, Any]] = []
+    grupos = df_tratado.groupby(["EquipeResumo", "MotivoResumo"], dropna=False)
+
+    for (equipe, motivo), grupo in grupos:
+        total = int(grupo.shape[0])
+        detalhes_df = (
+            grupo.groupby("PessoaResumo", dropna=False)
+            .size()
+            .reset_index(name="Quantidade")
+            .sort_values(by=["Quantidade", "PessoaResumo"], ascending=[False, True])
+        )
+
+        detalhes = [
+            {"nome": str(row["PessoaResumo"]), "qtd": int(row["Quantidade"])}
+            for _, row in detalhes_df.iterrows()
+        ]
+
+        resumo.append({
+            "equipe": str(equipe),
+            "tipo_relatorio": tipo_relatorio,
+            "motivo": str(motivo),
+            "qtd": total,
+            "detalhes": detalhes,
+        })
+
+    resumo.sort(key=lambda item: (item["equipe"], item["motivo"]))
+    return resumo

--- a/app/routes.py
+++ b/app/routes.py
@@ -198,6 +198,7 @@ def status(task_id):
             "stats": result["stats"],
             "debug": result.get("debug"),
             "nome_arquivo_log": result.get("nome_arquivo_log"),
+            "resumo": result.get("resumo", []),
         })
 
     if task["status"] == "error":

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -20,7 +20,7 @@ def enqueue_csv_processing(filepath: str, ignorar_sabados: bool, tipo_relatorio:
     def _run():
         _tasks[task_id]["status"] = "running"
         try:
-            logs, stats, nome_arquivo_log = processar_csv(
+            logs, stats, nome_arquivo_log, resumo_matricial = processar_csv(
                 filepath, ignorar_sabados, tipo_relatorio, equipes_selecionadas
             )
 
@@ -41,6 +41,7 @@ def enqueue_csv_processing(filepath: str, ignorar_sabados: bool, tipo_relatorio:
                 "logs": logs,
                 "stats": stats,
                 "nome_arquivo_log": nome_arquivo_log,
+                "resumo": resumo_matricial,
                 "debug": debug_data,
             }
             _tasks[task_id]["status"] = "done"

--- a/static/css/matrix.css
+++ b/static/css/matrix.css
@@ -1,0 +1,150 @@
+.matrix-container {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.matrix-empty {
+    padding: 18px;
+    text-align: center;
+    color: #6c757d;
+    background: #f1f3f5;
+    border-radius: 10px;
+    border: 1px dashed #ced4da;
+}
+
+.matrix-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    background-color: #ffffff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+}
+
+.matrix-table thead {
+    background: linear-gradient(135deg, #2d6cdf, #4b7bec);
+    color: #ffffff;
+}
+
+.matrix-table th,
+.matrix-table td {
+    padding: 14px 16px;
+    text-align: left;
+    font-size: 0.95rem;
+}
+
+.matrix-table th {
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.matrix-table tbody tr:nth-child(even) {
+    background-color: #f8f9fb;
+}
+
+.matrix-table tbody tr:hover {
+    background-color: #eef2ff;
+}
+
+.matrix-col-toggle {
+    width: 48px;
+    text-align: center;
+}
+
+.matrix-col-qtd {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.matrix-toggle-btn {
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 50%;
+    background: #ffffff;
+    color: #2d6cdf;
+    font-size: 1.1rem;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(45, 108, 223, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.matrix-toggle-btn:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 12px rgba(45, 108, 223, 0.35);
+}
+
+.matrix-toggle-btn:focus {
+    outline: 2px solid rgba(45, 108, 223, 0.4);
+    outline-offset: 2px;
+}
+
+.matrix-toggle-placeholder {
+    color: #adb5bd;
+    font-size: 0.9rem;
+}
+
+.matrix-drilldown td {
+    background-color: #f1f5ff;
+    border-top: 1px solid #dee2e6;
+}
+
+.drilldown-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.drilldown-title {
+    font-weight: 600;
+    color: #2d6cdf;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.drilldown-table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: #ffffff;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.drilldown-table th,
+.drilldown-table td {
+    padding: 10px 14px;
+    font-size: 0.9rem;
+}
+
+.drilldown-table thead {
+    background-color: #e9efff;
+    color: #2d3a55;
+}
+
+.drilldown-table tbody tr:nth-child(even) {
+    background-color: #f8f9ff;
+}
+
+.drilldown-empty {
+    padding: 10px 0;
+    color: #6c757d;
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    .matrix-table th,
+    .matrix-table td {
+        padding: 10px 12px;
+        font-size: 0.85rem;
+    }
+
+    .matrix-toggle-btn {
+        width: 28px;
+        height: 28px;
+        font-size: 1rem;
+    }
+}

--- a/static/js/eventos.js
+++ b/static/js/eventos.js
@@ -2,6 +2,7 @@ import { gerarFormData } from './helpers.js';
 import { enviarCSV, obterStatus } from './api.js';
 import { mostrarLogs, atualizarEstatisticas, mostrarDebug, atualizarBarraProgresso } from './ui.js';
 import { carregarDropdownEquipes } from './dropdown.js';
+import { atualizarResumoMatriz } from './matriz.js';
 
 // URL base da API interna (origem atual)
 const API_BASE_URL = window.location.origin;
@@ -82,6 +83,10 @@ export function configurarEventos() {
         const formData = gerarFormData(fileAtual, ignorarSabados, debugMode, equipesSelecionadas, tipoRelatorio);
 
         atualizarBarraProgresso("25%");
+        const matrixContainer = document.getElementById('matrixContainer');
+        if (matrixContainer) {
+            matrixContainer.innerHTML = '<div class="matrix-empty">Gerando resumo consolidado...</div>';
+        }
         console.info("📦 Enviando arquivo:", arquivoSelecionado);
 
         try {
@@ -92,6 +97,7 @@ export function configurarEventos() {
 
             mostrarLogs(resultado.log);
             atualizarEstatisticas(resultado.stats);
+            atualizarResumoMatriz(resultado.resumo);
             atualizarBarraProgresso("100%");
 
             if (debugMode && resultado.debug) {

--- a/static/js/matriz.js
+++ b/static/js/matriz.js
@@ -1,0 +1,165 @@
+const numberFormatter = new Intl.NumberFormat('pt-BR');
+
+function criarCelula(conteudo, classe = '') {
+    const td = document.createElement('td');
+    if (classe) {
+        td.className = classe;
+    }
+    if (conteudo instanceof Node) {
+        td.appendChild(conteudo);
+    } else {
+        td.textContent = conteudo;
+    }
+    return td;
+}
+
+function criarToggleButton(drillRow) {
+    const botao = document.createElement('button');
+    botao.type = 'button';
+    botao.className = 'matrix-toggle-btn';
+    botao.setAttribute('aria-expanded', 'false');
+    botao.setAttribute('title', 'Exibir detalhes por pessoa');
+    botao.innerHTML = '▸';
+
+    botao.addEventListener('click', () => {
+        const estaOculto = drillRow.classList.contains('hidden');
+        if (estaOculto) {
+            drillRow.classList.remove('hidden');
+            botao.setAttribute('aria-expanded', 'true');
+            botao.innerHTML = '▾';
+        } else {
+            drillRow.classList.add('hidden');
+            botao.setAttribute('aria-expanded', 'false');
+            botao.innerHTML = '▸';
+        }
+    });
+
+    return botao;
+}
+
+function criarTabelaDetalhes(item) {
+    const detalhes = Array.isArray(item.detalhes) ? item.detalhes : [];
+    const wrapper = document.createElement('div');
+    wrapper.className = 'drilldown-wrapper';
+
+    const titulo = document.createElement('div');
+    titulo.className = 'drilldown-title';
+    titulo.innerHTML = '👤 Detalhes por pessoa';
+    wrapper.appendChild(titulo);
+
+    if (!detalhes.length) {
+        const vazio = document.createElement('div');
+        vazio.className = 'drilldown-empty';
+        vazio.textContent = 'Nenhum detalhe disponível para esta combinação.';
+        wrapper.appendChild(vazio);
+        return wrapper;
+    }
+
+    const tabela = document.createElement('table');
+    tabela.className = 'drilldown-table';
+
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Nome</th><th class="matrix-col-qtd">Qtd</th></tr>';
+    tabela.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    const ordenado = [...detalhes].sort((a, b) => {
+        if (b.qtd === a.qtd) {
+            return a.nome.localeCompare(b.nome, 'pt-BR');
+        }
+        return b.qtd - a.qtd;
+    });
+
+    ordenado.forEach((detalhe) => {
+        const linha = document.createElement('tr');
+        linha.appendChild(criarCelula(detalhe.nome));
+        linha.appendChild(criarCelula(numberFormatter.format(detalhe.qtd), 'matrix-col-qtd'));
+        tbody.appendChild(linha);
+    });
+
+    tabela.appendChild(tbody);
+    wrapper.appendChild(tabela);
+    return wrapper;
+}
+
+export function atualizarResumoMatriz(resumo) {
+    const container = document.getElementById('matrixContainer');
+    if (!container) {
+        console.warn('Container da matriz não encontrado.');
+        return;
+    }
+
+    container.innerHTML = '';
+
+    if (!Array.isArray(resumo) || resumo.length === 0) {
+        const vazio = document.createElement('div');
+        vazio.className = 'matrix-empty';
+        vazio.textContent = 'Nenhum dado disponível. Envie um arquivo CSV para gerar o resumo.';
+        container.appendChild(vazio);
+        return;
+    }
+
+    const tabela = document.createElement('table');
+    tabela.className = 'matrix-table';
+
+    const thead = document.createElement('thead');
+    thead.innerHTML = `
+        <tr>
+            <th class="matrix-col-toggle" scope="col"></th>
+            <th scope="col">Equipe</th>
+            <th scope="col">Tipo de Relatório</th>
+            <th scope="col">Motivo</th>
+            <th class="matrix-col-qtd" scope="col">Qtd</th>
+        </tr>
+    `;
+    tabela.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    const dadosOrdenados = [...resumo].sort((a, b) => {
+        if (a.equipe === b.equipe) {
+            return a.motivo.localeCompare(b.motivo, 'pt-BR');
+        }
+        return a.equipe.localeCompare(b.equipe, 'pt-BR');
+    });
+
+    dadosOrdenados.forEach((item, indice) => {
+        const linha = document.createElement('tr');
+        linha.className = 'matrix-row';
+        const chave = `${indice}-${item.equipe}-${item.tipo_relatorio}-${item.motivo}`;
+        linha.dataset.key = chave;
+
+        const drillRow = document.createElement('tr');
+        drillRow.className = 'matrix-drilldown hidden';
+        drillRow.dataset.parentKey = chave;
+
+        const celulaToggle = document.createElement('td');
+        celulaToggle.className = 'matrix-col-toggle';
+        const possuiDetalhes = Array.isArray(item.detalhes) && item.detalhes.length > 0;
+        if (possuiDetalhes) {
+            const botao = criarToggleButton(drillRow);
+            celulaToggle.appendChild(botao);
+        } else {
+            const placeholder = document.createElement('span');
+            placeholder.className = 'matrix-toggle-placeholder';
+            placeholder.textContent = '—';
+            celulaToggle.appendChild(placeholder);
+        }
+        linha.appendChild(celulaToggle);
+
+        linha.appendChild(criarCelula(item.equipe));
+        linha.appendChild(criarCelula(item.tipo_relatorio));
+        linha.appendChild(criarCelula(item.motivo));
+        linha.appendChild(criarCelula(numberFormatter.format(item.qtd), 'matrix-col-qtd'));
+
+        const drillCell = document.createElement('td');
+        drillCell.colSpan = 5;
+        drillCell.appendChild(criarTabelaDetalhes(item));
+        drillRow.appendChild(drillCell);
+
+        tbody.appendChild(linha);
+        tbody.appendChild(drillRow);
+    });
+
+    tabela.appendChild(tbody);
+    container.appendChild(tabela);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/dropdown.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/logs.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/stats.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/matrix.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
 </head>
 <body>
@@ -189,6 +190,14 @@
                             <div id="errorCount" class="stat-number">0</div>
                             <div class="stat-label">Erros</div>
                         </div>
+                    </div>
+                </div>
+
+                <!-- Matrix Summary Card -->
+                <div class="card">
+                    <h3><span class="icon">📈</span>Resumo Interativo</h3>
+                    <div id="matrixContainer" class="matrix-container">
+                        <div class="matrix-empty">Envie um arquivo CSV para visualizar o resumo consolidado.</div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Resumo
- criar utilitário `gerar_resumo_matricial` para consolidar dados por equipe, tipo e motivo
- incluir o resumo matricial no retorno das tarefas e disponibilizá-lo via endpoint `/status`
- adicionar cartão "Resumo Interativo" com nova tabela matricial e drill-down por pessoa
- implementar estilos e módulo JavaScript para exibição interativa dos dados consolidados

## Testes
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c9cdde05c083338904e66903f0ae9b